### PR TITLE
Add autofocus for input video URL

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -3,7 +3,7 @@
 		<form class="" method="get" id="download" action="getvideo.php">
 			<h1 class="form-download-heading">Youtube Downloader</h1>
 				<div class="input-group">
-				  <input type="text" name="videoid" id="videoid" class="form-control input-lg" placeholder="YouTube Link or VideoID">
+				  <input type="text" name="videoid" id="videoid" class="form-control input-lg" placeholder="YouTube Link or VideoID" autofocus>
 				  <span class="input-group-btn">
 					<input class="btn btn-primary btn-lg" type="submit" name="type" id="type" value="Download" />
 				  </span>


### PR DESCRIPTION
This adds `autofocus` attribute to the input video URL field so that the pasting of URL is easier.